### PR TITLE
Update sandbox tests to expect Python 3.12

### DIFF
--- a/tests/sandbox/test_client.py
+++ b/tests/sandbox/test_client.py
@@ -38,7 +38,7 @@ async def test_sandbox_creation(local_client: LocalSandboxClient):
 
     await local_client.create(config)
     result = await local_client.run_command("python3 --version")
-    assert "Python 3.10" in result
+    assert "Python 3.12" in result
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_sandbox.py
+++ b/tests/sandbox/test_sandbox.py
@@ -91,7 +91,7 @@ async def test_sandbox_python_environment(sandbox):
     """Tests Python environment configuration."""
     # Test Python version
     result = await sandbox.terminal.run_command("python3 --version")
-    assert "Python 3.10" in result
+    assert "Python 3.12" in result
 
     # Test basic module imports
     python_code = """


### PR DESCRIPTION
## Summary
- adjust expected Python version string in sandbox tests

## Testing
- `pre-commit run --files tests/sandbox/test_client.py tests/sandbox/test_sandbox.py` *(fails: pre-commit: command not found)*
- `pytest -q tests/sandbox/test_client.py tests/sandbox/test_sandbox.py` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68417e1837c883229cd5765b1aa4a34f